### PR TITLE
imp(js): support lighttable through mime type

### DIFF
--- a/codemirror-docker.js
+++ b/codemirror-docker.js
@@ -108,3 +108,4 @@ CodeMirror.defineMode("docker", function() {
   };
 });
 
+CodeMirror.defineMIME("text/x-docker", "docker");


### PR DESCRIPTION
[lighttable](http://lighttable.com/) relies on codemirror js files, but in order to work, needs a mime type definition in the js file. Only when set, you're able to assign it.
